### PR TITLE
Update Readme.md: correct p=2^{64}-2^{32}+1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,6 @@
 Fast number theoretic transforms and polynomial commitments over the 64-bit Goldilocks prime field $\mathbb{F}_p$ with
 
 $$
-p = 2^{63} - 2^{32} + 1
+p = 2^{64} - 2^{32} + 1
 $$
 

--- a/ntt/Readme.md
+++ b/ntt/Readme.md
@@ -3,7 +3,7 @@
 Fast number theoretic transforms over the 64-bit Goldilocks prime field $\mathbb{F}_p$ with
 
 $$
-p = 2^{63} - 2^{32} + 1
+p = 2^{64} - 2^{32} + 1
 $$
 
 ## To do

--- a/pcs/Readme.md
+++ b/pcs/Readme.md
@@ -3,7 +3,7 @@
 Commit to polynomials in $\mathbb{F}_p[X]$ with
 
 $$
-p = 2^{63} - 2^{32} + 1
+p = 2^{64} - 2^{32} + 1
 $$
 
 


### PR DESCRIPTION
Corrected the p value typos in three Readme.md files. The previous value was `p=2^{63}-2^{32}+1`, which should be `p=2^{64}-2^{32}+1`.